### PR TITLE
Make the example compileable

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ To present a `UIAlertController` containing the `UIAlertAction`, nothing changes
 let alertController = UIAlertController(
   title: "Title",
   message: "Message",
-  preferredStyle: style
+  preferredStyle: .actionSheet
 )
 
 let settings = UIAlertAction(


### PR DESCRIPTION
This removes a reference to a dangling variable that was never explicitly there.