### PR TITLE
Added support to display a checkmark with `isSelected`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## Next
+## 3.2.0
+- Added support to display a checkmark with `isSelected`
 
 ## 3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Next
 
 ## 3.2.0
-- Added support to display a checkmark with `isSelected`
+- Added support to display a checkmark with `isChecked`
 
 ## 3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## Next
+
 ## 3.2.0
 - Added support to display a checkmark with `isSelected`
 

--- a/Example/ImageAlertAction/ViewController.swift
+++ b/Example/ImageAlertAction/ViewController.swift
@@ -15,6 +15,9 @@ class ViewController: UIViewController {
 
     let settings = UIAlertAction(title: "Settings", image: #imageLiteral(resourceName: "settings"), style: .default)
     alertController.addAction(settings)
+    
+    let selectedSettings = UIAlertAction(title: "Selected Settings", image: #imageLiteral(resourceName: "settings"), isSelected: true, style: .default)
+    alertController.addAction(selectedSettings)
 
     let cancel = UIAlertAction(title: "Cancel", style: .cancel)
     alertController.addAction(cancel)

--- a/Example/ImageAlertAction/ViewController.swift
+++ b/Example/ImageAlertAction/ViewController.swift
@@ -16,7 +16,7 @@ class ViewController: UIViewController {
     let settings = UIAlertAction(title: "Settings", image: #imageLiteral(resourceName: "settings"), style: .default)
     alertController.addAction(settings)
     
-    let selectedSettings = UIAlertAction(title: "Selected Settings", image: #imageLiteral(resourceName: "settings"), isSelected: true, style: .default)
+    let selectedSettings = UIAlertAction(title: "Checked Settings", image: #imageLiteral(resourceName: "settings"), isChecked: true, style: .default)
     alertController.addAction(selectedSettings)
 
     let cancel = UIAlertAction(title: "Cancel", style: .cancel)

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ImageAlertAction (3.1.0)
+  - ImageAlertAction (3.2.0)
 
 DEPENDENCIES:
   - ImageAlertAction (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  ImageAlertAction: 2f4d6ecd9d4896eb4bb959f9d1c8a1101d6805f4
+  ImageAlertAction: 5556758a632c531172c5b2afcc4a25417df9f5a2
 
 PODFILE CHECKSUM: 2861c5c31891940484aaf82fd18a1725282b6061
 

--- a/Example/Pods/Local Podspecs/ImageAlertAction.podspec.json
+++ b/Example/Pods/Local Podspecs/ImageAlertAction.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "ImageAlertAction",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "summary": "Image support for UIAlertAction",
   "description": "ImageAlertAction adds image support to UIAlertAction.\nUse this to visually convey an action's purpose.",
   "homepage": "https://github.com/BasThomas/ImageAlertAction",
@@ -17,7 +17,7 @@
   },
   "source": {
     "git": "https://github.com/BasThomas/ImageAlertAction.git",
-    "tag": "3.1.0"
+    "tag": "3.2.0"
   },
   "social_media_url": "https://twitter.com/basthomas",
   "platforms": {

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ImageAlertAction (3.1.0)
+  - ImageAlertAction (3.2.0)
 
 DEPENDENCIES:
   - ImageAlertAction (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  ImageAlertAction: 2f4d6ecd9d4896eb4bb959f9d1c8a1101d6805f4
+  ImageAlertAction: 5556758a632c531172c5b2afcc4a25417df9f5a2
 
 PODFILE CHECKSUM: 2861c5c31891940484aaf82fd18a1725282b6061
 

--- a/Example/Pods/Target Support Files/ImageAlertAction/ImageAlertAction-Info.plist
+++ b/Example/Pods/Target Support Files/ImageAlertAction/ImageAlertAction-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.1.0</string>
+  <string>3.2.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -8,12 +8,12 @@ class Tests: XCTestCase {
   }
     
     func testCheckmarkIsCorrectlySet() {
-      let action = UIAlertAction(title: "Hello world!", image: #imageLiteral(resourceName: "settings"), isSelected: true, style: .cancel)
-      XCTAssertTrue(action.isSelected)
+      let action = UIAlertAction(title: "Hello world!", image: #imageLiteral(resourceName: "settings"), isChecked: true, style: .cancel)
+      XCTAssertTrue(action.isChecked)
     }
     
     func testCheckmarkIsNotSet() {
       let action = UIAlertAction(title: "Hello world!", image: #imageLiteral(resourceName: "settings"), style: .cancel)
-      XCTAssertFalse(action.isSelected)
+      XCTAssertFalse(action.isChecked)
     }
 }

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -6,4 +6,14 @@ class Tests: XCTestCase {
     let action = UIAlertAction(title: "Hello world!", image: #imageLiteral(resourceName: "settings"), style: .cancel)
     XCTAssertNotNil(action.image)
   }
+    
+    func testCheckmarkIsCorrectlySet() {
+      let action = UIAlertAction(title: "Hello world!", image: #imageLiteral(resourceName: "settings"), isSelected: true, style: .cancel)
+      XCTAssertTrue(action.isSelected)
+    }
+    
+    func testCheckmarkIsNotSet() {
+      let action = UIAlertAction(title: "Hello world!", image: #imageLiteral(resourceName: "settings"), style: .cancel)
+      XCTAssertFalse(action.isSelected)
+    }
 }

--- a/ImageAlertAction.podspec
+++ b/ImageAlertAction.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'ImageAlertAction'
-  s.version          = '3.1.0'
+  s.version          = '3.2.0'
   s.summary          = 'Image support for UIAlertAction'
   s.description      = <<-DESC
 ImageAlertAction adds image support to UIAlertAction.

--- a/ImageAlertAction/Classes/UIAlertAction+Image.swift
+++ b/ImageAlertAction/Classes/UIAlertAction+Image.swift
@@ -11,6 +11,7 @@ import UIKit
 extension UIAlertAction {
 
     private var imageKey: String { "image" }
+    private var isSelectedKey: String { "checked" }
 
     /// Create and return an action with the specified title and behavior.
     ///
@@ -24,6 +25,7 @@ extension UIAlertAction {
     /// may be used with [UIAlertAction.Style.cancel](https://developer.apple.com/documentation/uikit/uialertaction/style/cancel).
     /// - parameter image: An image to display on the left side of the button.
     /// Use this to visually convey the action's purpose.
+    /// - parameter isSelected: A boolean that will be used to determine if a checkmark should be displayed on the right side of the title
     /// - parameter style: Additional styling information to apply to the button.
     /// Use the style information to convey the type of action that is performed by the button.
     /// For a list of possible values, see the constants in
@@ -36,13 +38,17 @@ extension UIAlertAction {
     public convenience init(
         title: String? = nil,
         image: UIImage,
+        isSelected: Bool = false,
         style: UIAlertAction.Style,
         handler: ((UIAlertAction) -> Void)? = nil
     ) {
         self.init(title: title, style: style, handler: handler)
         setValue(image, forKey: imageKey)
+        setValue(isSelected, forKey: isSelectedKey)
     }
 
     /// The image of the action's button.
     public var image: UIImage? { value(forKey: imageKey) as? UIImage }
+    
+    public var isSelected: Bool { value(forKey: isSelectedKey) as? Bool ?? false }
 }

--- a/ImageAlertAction/Classes/UIAlertAction+Image.swift
+++ b/ImageAlertAction/Classes/UIAlertAction+Image.swift
@@ -25,7 +25,7 @@ extension UIAlertAction {
     /// may be used with [UIAlertAction.Style.cancel](https://developer.apple.com/documentation/uikit/uialertaction/style/cancel).
     /// - parameter image: An image to display on the left side of the button.
     /// Use this to visually convey the action's purpose.
-    /// - parameter isChecked: A boolean that will be used to determine if a checkmark should be displayed on the right side of the title
+    /// - parameter isChecked: A boolean that will be used to determine if a check mark should be displayed on the right side of the title
     /// - parameter style: Additional styling information to apply to the button.
     /// Use the style information to convey the type of action that is performed by the button.
     /// For a list of possible values, see the constants in

--- a/ImageAlertAction/Classes/UIAlertAction+Image.swift
+++ b/ImageAlertAction/Classes/UIAlertAction+Image.swift
@@ -11,7 +11,7 @@ import UIKit
 extension UIAlertAction {
 
     private var imageKey: String { "image" }
-    private var isSelectedKey: String { "checked" }
+    private var isCheckedKey: String { "checked" }
 
     /// Create and return an action with the specified title and behavior.
     ///
@@ -25,7 +25,7 @@ extension UIAlertAction {
     /// may be used with [UIAlertAction.Style.cancel](https://developer.apple.com/documentation/uikit/uialertaction/style/cancel).
     /// - parameter image: An image to display on the left side of the button.
     /// Use this to visually convey the action's purpose.
-    /// - parameter isSelected: A boolean that will be used to determine if a checkmark should be displayed on the right side of the title
+    /// - parameter isChecked: A boolean that will be used to determine if a checkmark should be displayed on the right side of the title
     /// - parameter style: Additional styling information to apply to the button.
     /// Use the style information to convey the type of action that is performed by the button.
     /// For a list of possible values, see the constants in
@@ -38,17 +38,17 @@ extension UIAlertAction {
     public convenience init(
         title: String? = nil,
         image: UIImage,
-        isSelected: Bool = false,
+        isChecked: Bool = false,
         style: UIAlertAction.Style,
         handler: ((UIAlertAction) -> Void)? = nil
     ) {
         self.init(title: title, style: style, handler: handler)
         setValue(image, forKey: imageKey)
-        setValue(isSelected, forKey: isSelectedKey)
+        setValue(isChecked, forKey: isCheckedKey)
     }
 
     /// The image of the action's button.
     public var image: UIImage? { value(forKey: imageKey) as? UIImage }
     
-    public var isSelected: Bool { value(forKey: isSelectedKey) as? Bool ?? false }
+    public var isChecked: Bool { value(forKey: isCheckedKey) as? Bool ?? false }
 }

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ settings.image // returns an optional UIImage
 
 #### Adding a checkmark
 
-You can also show a checkmark on actions via `isChecked`
+You can also show a check mark on actions via `isChecked`
 
 ```swift
 let settings = UIAlertAction(

--- a/README.md
+++ b/README.md
@@ -68,16 +68,16 @@ settings.image // returns an optional UIImage
 
 #### Adding a checkmark
 
-You can also show a checkmark on actions via `isSelected`
+You can also show a checkmark on actions via `isChecked`
 
 ```swift
 let settings = UIAlertAction(
   title: "Settings",
   image: #imageLiteral(resourceName: "settings"),
-  isSelected: true
+  isChecked: true
   style: .default
 )
-settings.isSelected // returns a Bool
+settings.isChecked // returns a Bool
 ```
 
 ### Presenting the `UIAlertController`

--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ let settings = UIAlertAction(
 settings.image // returns an optional UIImage
 ```
 
+#### Adding a checkmark
+
+You can also show a checkmark on actions via `isSelected`
+
+```swift
+let settings = UIAlertAction(
+  title: "Settings",
+  image: #imageLiteral(resourceName: "settings"),
+  isSelected: true
+  style: .default
+)
+settings.isSelected // returns a Bool
+```
+
 ### Presenting the `UIAlertController`
 
 To present a `UIAlertController` containing the `UIAlertAction`, nothing changes.


### PR DESCRIPTION
* Bumps to version `3.2.0` (from `3.1.0`)
* Adds `isSelected` argument to `UIAlertAction`'s initialiser with a default value of `false` (non-breaking change)
* Adds two unit tests to cover `isSelected`
* Updates CHANGELOG.md with `3.2.0`
* Updates Example application with an example of `isSelected`
* Updates README.md with an example of `isSelected`


## Examples
<img width="545" alt="Screenshot 2020-01-19 at 14 20 54" src="https://user-images.githubusercontent.com/26525777/72682663-6e339a80-3ac7-11ea-9534-68a6c254c185.png">
<img width="545" alt="Screenshot 2020-01-19 at 14 20 58" src="https://user-images.githubusercontent.com/26525777/72682664-6e339a80-3ac7-11ea-976e-8e976a74188d.png">
